### PR TITLE
Autoroll damage improvements

### DIFF
--- a/scripts/mobAttackTool.js
+++ b/scripts/mobAttackTool.js
@@ -1,4 +1,7 @@
-export function  initMobAttackTool() {
+import { CustomItemRoll } from "../../betterrolls5e/scripts/custom-roll.js";
+
+
+export function initMobAttackTool() {
 	Hooks.on("getSceneControlButtons", (controls) => {
 		const bar = controls.find(c => c.name === "token");
 		bar.tools.push({
@@ -79,11 +82,15 @@ const d = new Dialog({
 						attacks[weapon] = numSelected;
 					}
 				}
-				
+
 				let betterrollsActive = false;
 				if (game.modules.get("betterrolls5e")?.active) {
 					betterrollsActive = true;
 				}
+				let midi_QOL_Active = false;
+				if (game.modules.get("midi-qol")?.active) {
+					midi_QOL_Active = true;
+				}		
 				
 				for ( let [key, value] of Object.entries(attacks) ) { 
 					const actorName = weapons[key].actor.name;
@@ -104,14 +111,44 @@ const d = new Dialog({
 						].join(``));
 						
 						(async () => {
-							for (let i = 0; i < numHitAttacks; i++) {
-								if (!betterrollsActive) {
-									await weapons[key].rollDamage();
-								} else {
-									await BetterRolls.quickRollByName(actorName,key);
+							if (betterrollsActive) {
+								let mobAttackRoll = await new CustomItemRoll(weapons[key], {
+										adv: 0,
+										consume: true,
+										disadv: 0,
+										forceCrit: false,
+										preset: 0,
+										prompt: {},
+										properties: true,
+										slotLevel: null,
+										rollState: null,
+										useCharge: {use: true, resource: true, charge: false},
+										useTemplate: true,
+										context: "",
+										quickRoll: true,
+									},
+									[
+										["header"],
+										["desc"],
+										["attack", {triggersCrit: false, formula: ("0d0 + " + targetAC)}],
+									]
+								);
+								for (let i = 0; i < numHitAttacks; i++) {
+									await mobAttackRoll.addField(["damage",{index: "all"}]);
 								}
-								await new Promise(resolve => setTimeout(resolve, 500));
+								await mobAttackRoll.addField(["ammo"]);
+								await mobAttackRoll.toMessage();
+							} else if (!midi_QOL_Active) { // neither midi-qol or betterrolls5e active
+								for (let i = 0; i < numHitAttacks; i++) {
+									await weapons[key].rollDamage({"critical": false, "event": {"shiftKey": true}});							
+								}
+							} else { // midi-qol is active,  betterrolls5e is not active
+								for (let i = 0; i < numHitAttacks; i++) {
+									// TODO: make it roll either only damage or have the attack roll match targetAC
+									await weapons[key].rollDamage({"critical": false, "event": {"shiftKey": true}});
+								}
 							}
+							await new Promise(resolve => setTimeout(resolve, 500));
 						})();
 					} else {
 						ui.notifications.warn("Attack bonus too low or not enough mob attackers to hit the target!");


### PR DESCRIPTION
Improvements are as follows:
* The module now technically (see TODO) doesn't depend on BetterRolls5e anymore, though it is integrated much more closely with it than previously.
* Mob Attacks are now rolled even if BetterRolls5e is inactive.
* If BetterRolls5e is active, then the Mob Attacks are also picked up by midi-qol (if that module is active). 
* The damage rolls from multiple mob attacks are condensed into one card if BetterRolls5e is active.

TODO:
* Find a way to use BetterRolls.rollItem() instead of importing CustomItemRoll, or find a way to catch import errors.
* For now BetterRolls5e will remain a dependency to prevent import errors during initialization.