### PR TITLE
mob selection improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4,8 +4,9 @@
 	"MAT.mobAttackResults": "Mob Attack Results",
 
 	"MAT.selectTokenWarning": "You need to select one or more tokens!",
-	"MAT.singleTargetWarning": "Make sure only a single token is targeted!",
+	"MAT.singleTargetWarning": "Make sure no more than one token is targeted!",
 	"MAT.targetValidACWarning": "Select a target with a valid AC value!",
+	"MAT.noTargetAllAttacksHitText": "No tokens are targeted, so all attacks will hit.",
 	"MAT.lowAttackBonusOrSmallMob": "Attack bonus too low or not enough mob attackers to hit the target!",
 	"MAT.ammoError": "There was an error while trying to add an ammo field to this {weaponName} attack.",
 	
@@ -13,6 +14,17 @@
 	"MAT.dialogChooseWeaponOption": "Choose weapon option",
 	"MAT.dialogNumSelected": "You have selected",
 	"MAT.dialogClickIconText": "Click icons to open actor or weapon sheets.",
+	"MAT.numAttacksTitle": "Number of Attacks",
+	"MAT.useWeaponTitle": "Use Weapon",
+
+	"MAT.selectMob": "Select mob",
+	"MAT.savedMobNotify": "{mobName} saved!",
+	"MAT.overwriteMobDialog": "There already exists a mob with the name \"{mobName}\". Do you want to overwrite it?",
+	"MAT.resetMobsNotify": "List of saved mobs was reset!",
+	"MAT.resetMobsDialog": "Reset all Mobs",
+	"MAT.mobNameDialog": "Mob name",
+	"MAT.saveMobButtonTitle": "Save Mob",
+	"MAT.loadMobButtonTitle": "Load Mob",
 
 	"MAT.macroNamePrefix": "Mob Attack of",
 	"MAT.macroNamePostfix": "(s)",
@@ -49,6 +61,7 @@
 	"Disadvantage": "Disadvantage",
 	"Conclusion": "Conclusion",
 	"of": "of",
+	"Select": "Select",
 
 	"SETTINGS.MAT.playerAccess": "Allow players to use Mob Attack Tool",
 	"SETTINGS.MAT.playerAccessHint": "If enabled, players will be able to see and use the Mob Attack Tool button. However, they will not see target AC. If disabled, only the GM will be able to use Mob Attack Tool.",
@@ -57,7 +70,7 @@
 	"SETTINGS.MAT.mobRules": "Mob Rules",
 	"SETTINGS.MAT.individualAttackRolls": "Individual Attack Rolls",
 	"SETTINGS.MAT.showIndividualAttackRolls": "Show individual attack rolls",
-	"SETTINGS.MAT.showIndividualAttackRollsHint": "Choose whether or not to show the successful individual attack rolls. Only relevant if rolling attacks individually instead of using mob rules. Midi-QOL support only in combination with Better Rolls for 5e for now. (Client specific setting)",
+	"SETTINGS.MAT.showIndividualAttackRollsHint": "Choose whether or not to show the successful individual attack rolls. Only relevant if rolling attacks individually instead of using mob rules. Midi-QOL support only in combination with Better Rolls for 5e for now, though Dice So Nice rolls will work regardless. (Client specific setting)",
 	"SETTINGS.MAT.showMultiattackDescription": "Show multiattack description",
 	"SETTINGS.MAT.showMultiattackDescriptionHint": "If enabled, then a multiattack description will be shown for any mob attacker that has a multiattack feature on their actor sheet. (Client specific setting)",
 	"SETTINGS.MAT.autoDetectMultiattacks": "Autodetect multiattack",

--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"url": "https://github.com/Stendarpaval/mob-attack-tool",
-	"version": "0.1.30",
+	"version": "0.1.31",
 	"minimumCoreVersion": "0.7.7",
 	"compatibleCoreVersion": "0.7.9",
 	"system": ["dnd5e"],
@@ -22,5 +22,5 @@
 		"styles/mob-attack-tool.css"
 	],
 	"manifest": "https://raw.githubusercontent.com/Stendarpaval/mob-attack-tool/main/module.json",
-	"download": "https://github.com/Stendarpaval/mob-attack-tool/releases/download/v0.1.30/module.zip"
+	"download": "https://github.com/Stendarpaval/mob-attack-tool/releases/download/v0.1.31/module.zip"
 }

--- a/scripts/mobAttack.js
+++ b/scripts/mobAttack.js
@@ -87,6 +87,42 @@ Hooks.once("init", () => {
 		type: Number
 	});
 
+	game.settings.register(MODULE, "hiddenMobList", {
+		name: "hiddenMobList",
+		hint: "hiddenMobList",
+		scope: "world",
+		config: false,
+		default: {},
+		type: Object
+	});	
+
+	game.settings.register(MODULE, "hiddenMobName", {
+		name: "hiddenMobName",
+		hint: "hiddenMobName",
+		scope: "world",
+		config: false,
+		default: "",
+		type: String
+	});	
+
+	game.settings.register(MODULE, "hiddenDialogContent", {
+		name: "hiddenDialogContent",
+		hint: "hiddenDialogContent",
+		scope: "world",
+		config: false,
+		default: "",
+		type: String
+	});	
+
+	game.settings.register(MODULE, "hiddenChangedMob", {
+		name: "hiddenChangedMob",
+		hint: "hiddenChangedMob",
+		scope: "world",
+		config: false,
+		default: false,
+		type: Boolean
+	});
+
 	initMobAttackTool();
 })
 

--- a/scripts/mobAttackTool.js
+++ b/scripts/mobAttackTool.js
@@ -369,6 +369,10 @@ class MobAttackDialog extends Dialog {
 			} else {
 				macroName = `${weapons[key].name} ${game.i18n.localize("MAT.macroNamePrefix")} ${mobList[Object.keys(mobList)[0]].numSelected} ${Object.keys(mobList)[0]}${game.i18n.localize("MAT.macroNamePostfix")}`;
 			}
+
+			if (game.settings.get("mob-attack-tool", "hiddenChangedMob")) {
+				numSelected = mobList[Object.keys(mobList)[0]].numSelected;
+			}
 			
 			Macro.create({
 				type: "script", 
@@ -752,6 +756,7 @@ async function rollMobAttack(data) {
 	let attackData = [];
 	let messageData = {messages: {}};
 	let isVersatile;
+	console.log(data.attacks);
 	for ( let [key, value] of Object.entries(data.attacks) ) { 
 		isVersatile = false;
 		if (key.endsWith(`(${game.i18n.localize("Versatile")})`.replace(" ", "-"))) {
@@ -766,6 +771,9 @@ async function rollMobAttack(data) {
 
 		// Check whether how many attackers can use this weapon
 		let availableAttacks = value;
+		console.log(attackersNeeded);
+		console.log(availableAttacks);
+		console.log(availableAttacks / attackersNeeded);
 		
 		if (availableAttacks / attackersNeeded >= 1) {
 			const numHitAttacks = Math.floor(availableAttacks/attackersNeeded);
@@ -816,9 +824,9 @@ async function rollMobAttack(data) {
 			await new Promise(resolve => setTimeout(resolve, 250));
 		} else {
 			ui.notifications.warn(game.i18n.localize("MAT.lowAttackBonusOrSmallMob"));
-			return;
 		}
 	}
+	if (attackData === []) return;
 
 	let totalPluralOrNot = ` ${game.i18n.localize((messageData.totalHitAttacks === 1) ? "MAT.numTotalHitsSingular" : "MAT.numTotalHitsPlural")}`;
 	messageData["totalPluralOrNot"] = totalPluralOrNot;

--- a/templates/mat-dialog-mob-list.html
+++ b/templates/mat-dialog-mob-list.html
@@ -1,0 +1,20 @@
+<form class="flexcol" autocomplete="off">
+	<section class="content">
+		<div class="form-group">
+			<label>{{localize 'MAT.selectMob'}}:</label>
+			<div class="form-fields">
+				<select name="selectMob">
+					{{#each this}}
+					<option value="{{this.mobName}}">{{this.mobName}}</option>
+					{{/each}}
+				</select>
+			</div>
+		</div>
+		<div class="form-group">
+			<label>{{localize 'MAT.resetMobsDialog'}}:</label>
+			<div class="form-fields">
+				<input type="checkbox" title="{{localize 'MAT.resetMobsDialog'}}" name="resetMobs"/>
+			</div>
+		</div>
+	</section>
+</form>

--- a/templates/mat-dialog-mob-selection.html
+++ b/templates/mat-dialog-mob-selection.html
@@ -1,0 +1,15 @@
+<section class="content">
+	<div class="form-group">
+		<label>{{localize 'MAT.mobNameDialog'}}:</label>
+		<div class="form-fields">
+			<input type="text" name="mobName" value="{{mobName}}"/>
+			<button type="button" title="{{localize 'MAT.saveMobButtonTitle'}}" name="saveMob" class="saveMobButton">
+				<i class="far fa-save"></i>
+			</button>
+			<button type="button" title="{{localize 'MAT.loadMobButtonTitle'}}" name="loadMob" class="loadMobButton">
+				<i class="fas fa-file-import fa-fw"></i>
+			</button>
+		</div>
+	</div>
+</section>
+<hr>

--- a/templates/mat-format-monster-label.html
+++ b/templates/mat-format-monster-label.html
@@ -1,7 +1,7 @@
 <div class="mat-monster-label">
 	<label class="mat-label mat-col1">{{actorAmount}}</label>
 	<label class="mat-label mat-col2">
-		<img class="mat-monster-icon" src="{{actorImg}}" title="{{actorNameImg}}" width="36" height="36" data-item-id="{{actorId}}">
+		<img class="mat-monster-icon" src="{{actorImg}}" title="Open {{actorNameImg}} sheet" width="36" height="36" data-item-id="{{actorId}}">
 	</label>
 	<label class="mat-label mat-col3 mat-monster-name">{{actorName}}</label>
 </div>

--- a/templates/mat-format-weapon-label.html
+++ b/templates/mat-format-weapon-label.html
@@ -1,12 +1,12 @@
 <div class="mat-weapon-label">
 	<label class="mat-label mat-col1">
-		<input type="number" name="{{numAttacksName}}" width="20" min="1" value="{{numAttack}}"/>
+		<input type="number" title="{{localize 'MAT.numAttacksTitle'}}" name="{{numAttacksName}}" width="20" min="1" value="{{numAttack}}"/>
 	</label>
 	<label class="mat-label mat-col2">
-		<img class="mat-weapon-icon" src="{{weaponImg}}" title="{{weaponNameImg}}" width="30" height="30" data-item-id="{{weaponId}}">
+		<img class="mat-weapon-icon" src="{{weaponImg}}" title="Open {{weaponNameImg}} sheet" width="30" height="30" data-item-id="{{weaponId}}">
 	</label>
 	<label class="mat-label mat-col3 mat-weapon-name">{{weaponName}}</label>
 	<label class="hint mat-label mat-col4">+{{weaponAttackBonus}} {{localize 'MAT.toHit'}}</label>
 	<label class="hint mat-label mat-col5 mat-damage-text">{{{weaponDamageText}}}</label>
-	<input class="mat-label mat-col6" type="checkbox" name="{{useButtonName}}" {{{useButtonValue}}}/>
+	<input class="mat-label mat-col6" title="{{localize 'MAT.useWeaponTitle'}}" type="checkbox" name="{{useButtonName}}" {{{useButtonValue}}}/>
 </div>


### PR DESCRIPTION
These improvements allow for the following:

- If using the "Roll Attacks Individually" instead of "Mob Rules", you don't need to have token targeted to use Mob Attack Tool. Mob Attack Tool will just assume that all attacks hit, unless a natural 1 is rolled.
- Mobs can be named and saved for future reuse. This functions similarly to macros, with the main benefit that you can manipulate which weapon options to use. Saved Mobs can also be reset.
- If you have saved Mobs, then you don't need to select any tokens before opening Mob Attack Tool. The first saved Mob will be loaded automatically.